### PR TITLE
Use CFData to instantiate CGDataProvider

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Run Tests
         run: ./.github/bin/test.sh
         env:
-          DESTINATION: OS=12.2,name=iPhone X
+          DESTINATION: OS=12.4,name=iPhone X
           SCHEME: WebP iOS
-          SDK: iphonesimulator12.2
+          SDK: iphonesimulator12.4
           WORKSPACE: WebP.xcworkspace

--- a/Sources/WebP/WebPDecoder+Platform.swift
+++ b/Sources/WebP/WebPDecoder+Platform.swift
@@ -12,36 +12,28 @@ extension WebPDecoder {
         let height: Int = options.useScaling ? options.scaledHeight : feature.height
         let width: Int = options.useScaling ? options.scaledWidth : feature.width
 
-        let decodedData: Data = try decode(byrgbA: webPData, options: options)
+        let decodedData: CFData = try decode(byrgbA: webPData, options: options) as CFData
+        let provider = CGDataProvider(data: decodedData)!
 
-        return try decodedData.withUnsafeBytes { rawPtr in
-            guard let bindedBasePtr = rawPtr.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
-                throw WebPError.unexpectedPointerError
-            }
+        let bitmapInfo = CGBitmapInfo(
+            rawValue: CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let renderingIntent = CGColorRenderingIntent.defaultIntent
+        let bytesPerPixel = 4
 
-            let provider = CGDataProvider(dataInfo: nil,
-                                          data: bindedBasePtr,
-                                          size: decodedData.count,
-                                          releaseData: { (_, _, _) in  })!
-            let bitmapInfo = CGBitmapInfo(
-                rawValue: CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
-            )
-            let colorSpace = CGColorSpaceCreateDeviceRGB()
-            let renderingIntent = CGColorRenderingIntent.defaultIntent
-            let bytesPerPixel = 4
-            
-            return CGImage(width: width,
-                           height: height,
-                           bitsPerComponent: 8,
-                           bitsPerPixel: 8 * bytesPerPixel,
-                           bytesPerRow: bytesPerPixel * width,
-                           space: colorSpace,
-                           bitmapInfo: bitmapInfo,
-                           provider: provider,
-                           decode: nil,
-                           shouldInterpolate: false,
-                           intent: renderingIntent)!
-        }
+        let cgImage = CGImage(width: width,
+                              height: height,
+                              bitsPerComponent: 8,
+                              bitsPerPixel: 8 * bytesPerPixel,
+                              bytesPerRow: bytesPerPixel * width,
+                              space: colorSpace,
+                              bitmapInfo: bitmapInfo,
+                              provider: provider,
+                              decode: nil,
+                              shouldInterpolate: false,
+                              intent: renderingIntent)!
+        return cgImage
     }
 }
 #endif


### PR DESCRIPTION
Closes #25 

I finally figured out the root cause which is CGDataProvider reads given data asynchronously when using this initialiser `CGDataProvider.init?(dataInfo: UnsafeMutableRawPointer?, data: UnsafeRawPointer, size: Int, releaseData: CGDataProviderReleaseDataCallback)`, meaning that decoded data will be automatically released as per how Swift treats value semantics. 

In order to fix the issue, this PR's change instead uses another initialiser of CGDataProvider which reads Data (as CFData) sychronously. This way we don't have to worry about the timing of releasing memory allocated in C-layer and released by value semantics's move.