### PR TITLE
Enable -fembed-bitcode

### DIFF
--- a/WebP.xcodeproj/project.pbxproj
+++ b/WebP.xcodeproj/project.pbxproj
@@ -1610,6 +1610,7 @@
 				OTHER_CFLAGS = (
 					"-DWEBP_SWAP_16BIT_CSP",
 					"-DNDEBUG",
+					"-fembed-bitcode",
 				);
 				PRODUCT_NAME = webp;
 				SKIP_INSTALL = YES;
@@ -1625,6 +1626,7 @@
 				OTHER_CFLAGS = (
 					"-DWEBP_SWAP_16BIT_CSP",
 					"-DNDEBUG",
+					"-fembed-bitcode",
 				);
 				PRODUCT_NAME = webp;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Closes #32 

It seems like we don't have to specify -DWEBP_USE_SSE2 manually.
https://github.com/webmproject/libwebp/blob/0fe1a89dbf1930fc2554dbe76adad5d962054ead/src/dsp/dsp.h#L67-L77 

So I just added the flag to enable bitcode on iOS platform.