### PR TITLE
Revert deployment targets in 0.6.0 and sync docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@
 This repository is a Swift wrapper around `libwebp` for encoding, decoding, and inspecting WebP data.
 Use this file as the execution guide for ongoing implementation and maintenance work.
 
-## Current Baseline (2026-02-17)
+## Current Baseline (2026-02-19)
 
 - Swift toolchain: 6.2.3 (`.swift-version`), `swift-tools-version: 6.2` (`swiftLanguageModes: [.v6]`)
-- Deployment targets: iOS 17+, macOS 14+
+- Deployment targets: iOS 13+, macOS 11+
 - Dependency:
   - [`libwebp-Xcode`](https://github.com/SDWebImage/libwebp-Xcode.git) 1.5.0+
   - [`SwiftFormat`](https://github.com/nicklockwood/SwiftFormat.git) via SPM plugin

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "WebP",
     platforms: [
-        .iOS(.v17),
-        .macOS(.v14)
+        .iOS(.v13),
+        .macOS(.v11),
     ],
     products: [
         .library(name: "WebP", targets: ["WebP"]),

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Swift-WebP provides Swift wrappers around `libwebp` for encoding, decoding, and 
 - Swift toolchain: 6.2.3 (`.swift-version`)
 - Swift language mode: 6
 - libwebp: 1.5.0+ (via `libwebp-Xcode`)
-- iOS deployment target: 17.0+
-- macOS deployment target: 14.0+
+- iOS deployment target: 13.0+
+- macOS deployment target: 11.0+
 
 ## Features
 


### PR DESCRIPTION
## Summary

- revert package deployment targets to iOS 13 / macOS 11
- update README support versions to match package targets
- update AGENTS baseline date/targets

https://github.com/ainame/Swift-WebP/pull/62#issuecomment-3926123203

## Verification

- swift build
- swift test